### PR TITLE
First iteration of batch flows, implemented on Canvas only

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,6 @@ interface ExtendedMetadataCache extends MetadataCache {
 }
 
 export async function getBacklinksForFile(file: TFile, app: App): Promise<CustomArrayDict<LinkCache>> {
-  const filePath = file.path;
   try {
     return await (app.metadataCache as ExtendedMetadataCache).getBacklinksForFile(file);
   } catch (error) {


### PR DESCRIPTION
Batches are trigged off files in additional context with `.index.md` extensions. Links from the `.index.md` files are substituted into the flow and one flow per link is executed, only one `.index.md` is supported due to cartesian explosions otherwise.