### PR TITLE
Batching plus link recurse plus flow chaining

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -685,16 +685,11 @@ export default class CloudAtlasPlugin extends Plugin {
 			return;
 		}
 		const inputNode = inputNodes[0];
-		const inputNodeEdges = findNodeEdges(inputNode, canvasContent.edges);
-		const connectedNodeIds = inputNodeEdges.map((edge) => edge.fromNode);
-		const connectedNodes = canvasContent.nodes.filter((node) => {
-			return connectedNodeIds.includes(node.id);
-		});
 		const input = await this.getNodeContent(inputNode);
 		const user_prompt = [];
 		for (const node of filterNodesByType(
 			NodeType.UserPrompt,
-			connectedNodes
+			canvasContent.nodes
 		)) {
 			const content = await this.getNodeContent(node);
 			if (content) {
@@ -702,7 +697,10 @@ export default class CloudAtlasPlugin extends Plugin {
 			}
 		}
 		const system_instructions = [];
-		for (const node of filterNodesByType(NodeType.System, connectedNodes)) {
+		for (const node of filterNodesByType(
+			NodeType.System,
+			canvasContent.nodes
+		)) {
 			const content = await this.getNodeContent(node);
 			if (content) {
 				system_instructions.push(content);
@@ -712,7 +710,7 @@ export default class CloudAtlasPlugin extends Plugin {
 		const additional_context: AdditionalContext = {};
 		const promises = filterNodesByType(
 			NodeType.Context,
-			connectedNodes
+			canvasContent.nodes
 		).map(async (node) => {
 			const content = await this.getNodeContent(node);
 			if (content) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,6 @@ interface ExtendedMetadataCache extends MetadataCache {
 }
 
 export async function getBacklinksForFile(file: TFile, app: App): Promise<CustomArrayDict<LinkCache>> {
-  const filePath = file.path;
   try {
     return await (app.metadataCache as ExtendedMetadataCache).getBacklinksForFile(file);
   } catch (error) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,30 +1,45 @@
 import { readFileSync } from "fs";
 import WordExtractor from "word-extractor";
 import { AdditionalContext, Payload, User } from "./interfaces";
-import { App, LinkCache, MetadataCache, Notice, TAbstractFile, TFile } from "obsidian";
+import {
+	App,
+	LinkCache,
+	MetadataCache,
+	Notice,
+	TAbstractFile,
+	TFile,
+} from "obsidian";
 import { CustomArrayDict } from "obsidian-typings";
 
 // Utility function to safely get a TFile by path
-export  function getFileByPath(filePath: string, app: App): TFile {
-  const file: TAbstractFile | null = app.vault.getAbstractFileByPath(filePath);
-  if (file instanceof TFile) {
-    return file;
-  } else {
-    throw new Error(`The path ${filePath} does not refer to a valid file.`);
-  }
+export function getFileByPath(filePath: string, app: App): TFile {
+	const file: TAbstractFile | null =
+		app.vault.getAbstractFileByPath(filePath);
+	if (file instanceof TFile) {
+		return file;
+	} else {
+		throw new Error(`The path ${filePath} does not refer to a valid file.`);
+	}
 }
 
 interface ExtendedMetadataCache extends MetadataCache {
-  getBacklinksForFile(file: TFile): CustomArrayDict<LinkCache>;
+	getBacklinksForFile(file: TFile): CustomArrayDict<LinkCache>;
 }
 
-export async function getBacklinksForFile(file: TFile, app: App): Promise<CustomArrayDict<LinkCache>> {
-  try {
-    return await (app.metadataCache as ExtendedMetadataCache).getBacklinksForFile(file);
-  } catch (error) {
-    new Notice('Backlink resolution failed. Consider installing the Backlink Cache Plugin.');
-    return {} as CustomArrayDict<LinkCache>;
-  }
+export async function getBacklinksForFile(
+	file: TFile,
+	app: App
+): Promise<CustomArrayDict<LinkCache>> {
+	try {
+		return await (
+			app.metadataCache as ExtendedMetadataCache
+		).getBacklinksForFile(file);
+	} catch (error) {
+		new Notice(
+			"Backlink resolution failed. Consider installing the Backlink Cache Plugin."
+		);
+		return {} as CustomArrayDict<LinkCache>;
+	}
 }
 
 export function combinePayloads(
@@ -74,7 +89,10 @@ export function joinStrings(
 	return [first, second].filter((s) => s).join("\n");
 }
 
-export async function getImageContent(basePath: string, path: string) {
+export async function getImageContent(
+	basePath: string,
+	path: string
+): Promise<string> {
 	const contents = readFileSync(`${basePath}/${path}`);
 	const buffedInput = Buffer.from(contents).toString("base64");
 
@@ -99,6 +117,14 @@ export function isImage(path: string): boolean {
 	);
 }
 
+export function isFlow(path: string): boolean {
+	return path.endsWith(".flowrun.md");
+}
+
+export function isCanvasFlow(path: string): boolean {
+	return path.endsWith(".flow.canvas");
+}
+
 export function isWord(path: string): boolean {
 	return path.endsWith(".docx") || path.endsWith(".doc");
 }
@@ -114,21 +140,18 @@ export function isOtherText(path: string): boolean {
 export async function getWordContents(
 	basePath: string,
 	path: string
-): Promise<string | undefined> {
+): Promise<string | null> {
 	const extractor = new WordExtractor();
 	const extracted = await extractor.extract(`${basePath}/${path}`);
 	return extracted.getBody();
 }
 
-export function getFileContents(
-	basePath: string,
-	path: string
-): string | undefined {
+export function getFileContents(basePath: string, path: string): string | null {
 	const contents = readFileSync(`${basePath}/${path}`);
 	try {
 		return new TextDecoder("utf8", { fatal: true }).decode(contents);
 	} catch (e) {
 		console.debug(e);
-		return;
+		return null;
 	}
 }


### PR DESCRIPTION
+ batching via `.index.md` files
+ arrows optional in canvas
+ `recurseLinks` frontmatter property

### Flow chaining

Adds support for `flowrun.md` file type, which can be used for flow chaining. Naming structure of the `flowrun.md` file must be `<name>.<flow-name>.flowrun.md`, ie `meeting.summarize call.flowrun.md`.

When a `flowrun` file is encountered anywhere, referenced flow is executed on the contents for the `flowrun` file, and result is substituted instead of the `flowrun` file contents. This works in both `canvas` and `md` flows. 

In addition to flowrun files entire canvas flows can be used in flow chains.  When a `.flow.canvas` files is encountered as a link, the canvas flow is executed and output is substituted instead of canvas file context, this works arbitrarily deep in the flow stack as long as links are resolved.