### PR TITLE
Intent engine, and a plethora of improvements

### DIFF
--- a/src/byollm.ts
+++ b/src/byollm.ts
@@ -9,39 +9,41 @@ export interface RequestMsg {
 
 function payloadToMessages(payload: Payload): RequestMsg[] {
 	const messages = [];
-	if (payload.system) {
-		const system_msg: RequestMsg = {
-			role: "system",
-			content: payload.system || "",
-		};
-		messages.push(system_msg);
-	}
-	if (payload.user?.user_prompt) {
-		const user_prompt_msg: RequestMsg = {
-			role: "user",
-			content: payload.user?.user_prompt || "",
-		};
-		messages.push(user_prompt_msg);
-	}
-
-	if (payload.user?.additional_context) {
-		for (const [key, value] of Object.entries(
-			payload.user?.additional_context
-		)) {
-			const additional_context_msg: RequestMsg = {
-				role: "user",
-				content: `additional_context -${key}: ${value}\n`,
+	for (const p of payload.messages) {
+		if (p.system) {
+			const system_msg: RequestMsg = {
+				role: "system",
+				content: p.system || "",
 			};
-			messages.push(additional_context_msg);
+			messages.push(system_msg);
 		}
+		if (p.user?.user_prompt) {
+			const user_prompt_msg: RequestMsg = {
+				role: "user",
+				content: p.user?.user_prompt || "",
+			};
+			messages.push(user_prompt_msg);
+		}
+
+		if (p.user?.additional_context) {
+			for (const [key, value] of Object.entries(
+				p.user?.additional_context
+			)) {
+				const additional_context_msg: RequestMsg = {
+					role: "user",
+					content: `additional_context -${key}: ${value}\n`,
+				};
+				messages.push(additional_context_msg);
+			}
+		}
+
+		const input_msg: RequestMsg = {
+			role: "user",
+			content: p.user?.input || "",
+		};
+
+		messages.push(input_msg);
 	}
-
-	const input_msg: RequestMsg = {
-		role: "user",
-		content: payload.user?.input || "",
-	};
-
-	messages.push(input_msg);
 
 	return messages;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,8 @@ export const DEFAULT_SETTINGS: CloudAtlasPluginSettings = {
 	},
 	provider: "openai",
 	registeredFlows: [],
+	createNewFile: false,
+	outputFileTemplate: "${basename}-${flow}-${timestamp}",
 	autoProcessing: {
 		enabled: false,
 		defaultFlow: "example"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,6 +44,11 @@ export const DEFAULT_SETTINGS: CloudAtlasPluginSettings = {
 	autoProcessing: {
 		enabled: false,
 		defaultFlow: "example"
+	},
+	interactivePanel: {
+		resolveLinks: false,
+		resolveBacklinks: false,
+		expandUrls: false
 	}
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,10 @@ export const DEFAULT_SETTINGS: CloudAtlasPluginSettings = {
 	},
 	provider: "openai",
 	registeredFlows: [],
+	autoProcessing: {
+		enabled: false,
+		defaultFlow: "example"
+	}
 };
 
 export const exampleFlowString = `---

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,7 +56,9 @@ export const exampleFlowString = `---
 system_instructions: You are a helpful assistant.
 resolveBacklinks: true
 resolveForwardLinks: true
+expandUrls: true
 exclusionPattern: ["^Private/", ".*-confidential.*"]
+can_delegate: false
 ---
 
 Say hello to the user.

--- a/src/flow_view.ts
+++ b/src/flow_view.ts
@@ -37,7 +37,12 @@ export class FlowView extends ItemView {
 					file.path.startsWith("CloudAtlas/") &&
 					file.path.endsWith(".flow.md")
 			)
-			.map((f) => f.path.split("/")[1].split(".flow.md")[0])
+			.map((f) => {
+				const path = f.path;
+				const afterCloudAtlas = path.substring(path.indexOf("CloudAtlas/") + "CloudAtlas/".length);
+				const beforeFlowMd = afterCloudAtlas.substring(0, afterCloudAtlas.indexOf(".flow.md"));
+				return beforeFlowMd;
+			})
 			.sort();
 
 		console.debug(`Found ${cloudAtlasFlows.length} CloudAtlas flows`);

--- a/src/flow_view.ts
+++ b/src/flow_view.ts
@@ -1,4 +1,4 @@
-import { ItemView, Notice, WorkspaceLeaf, setIcon } from "obsidian";
+import { ItemView, Notice, WorkspaceLeaf, setIcon, setTooltip } from "obsidian";
 import CloudAtlasPlugin from "./main";
 
 export const CA_VIEW_TYPE = "flow-view";
@@ -56,6 +56,7 @@ export class FlowView extends ItemView {
 			const td2 = tr.createEl("td");
 			const runBtn = td2.createEl("button", { text: "Run" });
 			setIcon(runBtn, "play");
+			setTooltip(runBtn, "Run Flow");
 			runBtn.addClass("cloud-atlas-flow-btn-primary");
 			runBtn.addEventListener("click", async () => {
 				// console.debug(`Running flow ${flow}`);
@@ -64,6 +65,8 @@ export class FlowView extends ItemView {
 			// const uploadTd = tr.createEl("td");
 			const uploadBtn = td2.createEl("button", { text: "Upload" });
 			setIcon(uploadBtn, "upload");
+			setTooltip(uploadBtn, "Upload Flow");
+			uploadBtn.disabled = true;
 			uploadBtn.addClass("cloud-atlas-flow-btn-primary");
 			uploadBtn.addEventListener("click", async () => {
 				// console.debug(`Uploading flow ${flow}`);
@@ -71,6 +74,8 @@ export class FlowView extends ItemView {
 			});
 			const deployBtn = td2.createEl("button", { text: "Deploy" });
 			setIcon(deployBtn, "cloud-cog");
+			setTooltip(deployBtn, "Deploy Flow");
+			deployBtn.disabled = true;
 			deployBtn.addClass("cloud-atlas-flow-btn-primary");
 			deployBtn.addEventListener("click", async () => {
 				// console.debug(`Uploading flow ${flow}`);

--- a/src/interactive_panel.ts
+++ b/src/interactive_panel.ts
@@ -320,6 +320,7 @@ export class InteractivePanel extends ItemView {
 		history.push(requestMsg);
 
 		const payload: Payload = {
+			model: null,
 			messages: history,
 			options: {
 				generate_embeddings: this.settings.generateEmbeddings,

--- a/src/interactive_panel.ts
+++ b/src/interactive_panel.ts
@@ -1,5 +1,5 @@
 import { ItemView, Notice, WorkspaceLeaf, setIcon } from "obsidian";
-import CloudAtlasPlugin  from "./main";
+import CloudAtlasPlugin from "./main";
 
 import { Payload } from "./interfaces";
 import ShortUniqueId from "short-unique-id";
@@ -26,254 +26,317 @@ const animateNotice = (notice: Notice) => {
 };
 
 export class InteractivePanel extends ItemView {
-  plugin: CloudAtlasPlugin;
-  attachedFiles: Set<string>;
-  settings: import("./settings").CloudAtlasPluginSettings;
-  responseContainer: HTMLDivElement;
-  responsePre: HTMLPreElement;
-  responseCode: HTMLElement;
-  loadingIndicator: HTMLDivElement;
-  copyButton: HTMLButtonElement;
+	plugin: CloudAtlasPlugin;
+	attachedFiles: Set<string>;
+	attachedFilesListEl: HTMLElement;
+	settings: import("./settings").CloudAtlasPluginSettings;
+	responseContainer: HTMLDivElement;
+	responsePre: HTMLPreElement;
+	responseCode: HTMLElement;
+	loadingIndicator: HTMLDivElement;
+	copyButton: HTMLButtonElement;
 
-  constructor(leaf: WorkspaceLeaf, plugin: CloudAtlasPlugin) {
-    super(leaf);
-    this.plugin = plugin;
-    this.settings = this.plugin.settings;
-    this.attachedFiles = new Set(); // Initialize the Set
-  }
+	constructor(leaf: WorkspaceLeaf, plugin: CloudAtlasPlugin) {
+		super(leaf);
+		this.plugin = plugin;
+		this.settings = this.plugin.settings;
+		this.attachedFiles = new Set(); // Initialize the Set
+		// attachedFilesListEl will be set in onOpen
+	}
 
-  setLoading(loading: boolean) {
-    if (loading) {
-      this.loadingIndicator.style.display = "block";
-    } else {
-      this.loadingIndicator.style.display = "none";
-    }
-  }
+	setLoading(loading: boolean) {
+		if (loading) {
+			this.loadingIndicator.style.display = "block";
+		} else {
+			this.loadingIndicator.style.display = "none";
+		}
+	}
 
-  getViewType() {
-    return INTERACTIVE_PANEL_TYPE;
-  }
+	getViewType() {
+		return INTERACTIVE_PANEL_TYPE;
+	}
 
-  getIcon(): string {
-    return "cloud-cog";
-  }
+	getIcon(): string {
+		return "cloud-cog";
+	}
 
-  getDisplayText() {
-    return "Cloud Atlas Interactive Mode";
-  }
+	getDisplayText() {
+		return "Cloud Atlas Interactive Mode";
+	}
 
-  createUserPromptTextbox() {
-    // Implement the logic for creating the user prompt textbox here.
-    const promptTextbox = document.createElement('textarea');
-    promptTextbox.placeholder = 'Enter your prompt here...';
-    promptTextbox.classList.add('ca-interactive-prompt-textbox');
-    this.containerEl.appendChild(promptTextbox);
-    return promptTextbox;
-  }
+	createUserPromptTextbox() {
+		// Implement the logic for creating the user prompt textbox here.
+		const promptTextbox = document.createElement("textarea");
+		promptTextbox.placeholder = "Enter your prompt here...";
+		promptTextbox.classList.add("ca-interactive-prompt-textbox");
+		this.containerEl.appendChild(promptTextbox);
+		return promptTextbox;
+	}
 
-  createAttachedFilesList() {
-    const attachedFilesList = this.containerEl.createDiv({ cls: 'attached-notes-list' });
-    const listHeader = attachedFilesList.createEl('h4', { text: 'Attached Notes' });
-    listHeader.style.marginBottom = '1em';
-    const filesList = attachedFilesList.createEl('ul');
-    filesList.style.height = '200px'; // Set a fixed height
-    filesList.style.overflowY = 'auto'; // Make it scrollable
-    return filesList;
-  }
+	createAttachedFilesList() {
+		const attachedFilesList = this.containerEl.createDiv({
+			cls: "attached-notes-list",
+		});
+		const listHeader = attachedFilesList.createEl("h4", {
+			text: "Attached Notes",
+		});
+		listHeader.style.marginBottom = "1em";
+		const filesList = attachedFilesList.createEl("ul");
+		filesList.style.height = "200px"; // Set a fixed height
+		filesList.style.overflowY = "auto"; // Make it scrollable
+		return filesList;
+	}
 
-  // Function to update the attached files list
-  updateAttachedFilesList(filesList: HTMLElement) {
-    filesList.empty();
-    if (this.attachedFiles.size === 0) {
-      filesList.createEl('li', { text: 'No notes attached.' });
-    } else {
-      this.attachedFiles.forEach(file => {
-        const listItem = filesList.createEl('li', { text: file });
-        const removeButton = listItem.createEl('button', {
-          text: 'Remove',
-          cls: 'remove-button',
-        });
-        removeButton.onClickEvent(() => {
-          this.attachedFiles.delete(file);
-          this.updateAttachedFilesList(filesList);
-        });
-      });
-    }
-  }
+	// Function to update the attached files list
+	updateAttachedFilesList(filesList: HTMLElement) {
+		filesList.empty();
+		if (this.attachedFiles.size === 0) {
+			filesList.createEl("li", { text: "No notes attached." });
+		} else {
+			this.attachedFiles.forEach((file) => {
+				const listItem = filesList.createEl("li", { text: file });
+				const removeButton = listItem.createEl("button", {
+					text: "Remove",
+					cls: "cloud-atlas-flow-btn-primary",
+				});
+				setIcon(removeButton, "trash-2");
+				removeButton.onClickEvent(() => {
+					this.attachedFiles.delete(file);
+					this.updateAttachedFilesList(filesList);
+				});
+			});
+		}
+	}
 
-  // Updated onOpen method
-  async onOpen() {
-    const container = this.containerEl.children[1];
-    container.empty();
-    container.createEl('h4', { text: 'Cloud Atlas Interactive Mode' });
+	// Updated onOpen method
+	async onOpen() {
+		const container = this.containerEl.children[1];
+		container.empty();
+		container.createEl("h4", { text: "Cloud Atlas Interactive Mode" });
 
-    // User prompt text box
-    const prompt = this.createUserPromptTextbox();
-    container.appendChild(prompt);
+		// Create the user prompt text box
+		const prompt = this.createUserPromptTextbox();
+		container.appendChild(prompt);
 
-    // Attach button
-    const attachButton = container.createEl('button', {
-      cls: 'ca-attach-note-button',
-      text: '+',
-    });
+		// Display a tip message for submitting using Ctrl+Enter
+		const tip = container.createEl("p", { text: "Ctrl+Enter to submit" });
+		tip.addClass("submit-tip");
+		tip.style.fontSize = "0.8em";
+		tip.style.color = "var(--text-muted)";
+		tip.style.marginTop = "4px";
 
-    container.createDiv();
+		// Create a container to hold the inline action buttons
+		const actionButtonContainer = container.createDiv();
+		actionButtonContainer.style.display = "flex";
+		actionButtonContainer.style.alignItems = "center";
+		actionButtonContainer.style.gap = "8px";
 
-    // Send button
-    const sendButton = container.createEl('button', {
-      cls: 'send-button',
-      text: 'Send to LLM',
-    });
+		// Inline Attach button (using style from flows view)
+		const attachButton = actionButtonContainer.createEl("button", {
+			cls: "ca-attach-note-button cloud-atlas-flow-btn-primary",
+			text: "+",
+		});
 
-    // Attached files list
-    const attachedFilesList = this.createAttachedFilesList();
-    this.updateAttachedFilesList(attachedFilesList);
+		// Make the attach button square and larger
+		setIcon(attachButton, "file-plus");
+		// Click listener for attaching the current note
+		attachButton.addEventListener("click", () => {
+			const activeFile = this.app.workspace.getActiveFile();
+			if (activeFile) {
+				console.debug("Attaching file: ", activeFile.path);
+				this.attachedFiles.add(activeFile.path);
+				new Notice(`Attached file: ${activeFile.path}`);
+				// Update our stored attached files list element
+				this.updateAttachedFilesList(this.attachedFilesListEl);
+			} else {
+				new Notice("No file is currently open.");
+			}
+		});
 
-    // Copy to Clipboard button and Response header positioning
-    const responseHeader = container.createEl('h4', { text: 'Response' });
-    this.copyButton = container.createEl('button', { text: 'Copy to Clipboard', cls: 'ca-a-interactive-copy-button' });
-    this.copyButton.hide();
-    responseHeader.insertAdjacentElement('afterend', this.copyButton);
+		// Inline Send button (using style from flows view)
+		const sendButton = actionButtonContainer.createEl("button", {
+			cls: "send-button cloud-atlas-flow-btn-primary",
+			text: "Send to LLM",
+		});
 
-    // Listener for the Copy to Clipboard button
-    this.copyButton.onClickEvent(() => {
-      if (this.responseCode) {
-        navigator.clipboard.writeText(this.responseCode.innerText).then(() => {
-          new Notice('Response copied to clipboard.');
-        }, (err) => {
-          console.error('Could not copy text: ', err);
-          new Notice('Failed to copy response to clipboard.');
-        });
-      }
-    });
+		setIcon(sendButton, "play");
+		// Make the send button square and larger so the text fits
 
-    // Response container
-    this.responseContainer = container.createDiv({ cls: 'response-container' });
-    this.responsePre = this.responseContainer.createEl('pre', { cls: 'ca-scrollable-response' });
-    this.responseCode = this.responsePre.createEl('code');
-    this.responseCode.addClass('ca-response-code');
+		sendButton.addEventListener("click", async () => {
+			if (prompt.value.trim() === "") {
+				new Notice("Please enter a prompt before sending.");
+				return;
+			}
+			await this.handleSendClick(prompt.value);
+		});
 
-    // Loading indicator
-    this.loadingIndicator = container.createDiv({ cls: 'loading-indicator' });
-    setIcon(this.loadingIndicator, 'sync');
-    this.loadingIndicator.setText(' Waiting for response');
-    this.setLoading(false); // Initially hidden
+		// Keydown listener for Ctrl+Enter to submit the prompt
+		prompt.addEventListener("keydown", (event: KeyboardEvent) => {
+			if (event.ctrlKey && event.key === "Enter") {
+				event.preventDefault();
+				event.stopPropagation();
+				sendButton.click();
+			}
+		});
 
-    // Event listeners
-    sendButton.onClickEvent(async () => {
-      if (prompt.value.trim() === "") {
-        new Notice("Please enter a prompt before sending.");
-        return;
-      }
-      await this.handleSendClick(prompt.value);
-    });
+		// Create and store the attached files list (UL element)
+		this.attachedFilesListEl = this.createAttachedFilesList();
+		this.updateAttachedFilesList(this.attachedFilesListEl);
 
-    attachButton.onClickEvent(() => {
-      const activeFile = this.app.workspace.getActiveFile();
-      if (activeFile) {
-        this.attachedFiles.add(activeFile.path);
-        new Notice(`Attached file: ${activeFile.path}`);
-        this.updateAttachedFilesList(attachedFilesList);
-      } else {
-        new Notice("No file is currently open.");
-      }
-    });
-  }
+		// Response header and Copy button setup
+		const responseHeader = container.createEl("h4", { text: "Response" });
+		this.copyButton = container.createEl("button", {
+			text: "Copy to Clipboard",
+			cls: "ca-a-interactive-copy-button",
+		});
+		this.copyButton.hide();
+		responseHeader.insertAdjacentElement("afterend", this.copyButton);
 
-  private async handleSendClick(promptValue: string) {
-    // Build the payload using the promptValue and attached files
-    const payload: Payload = {
-      user: {
-        user_prompt: promptValue,
-        input: "See Additional Context and Respond to Prompt",
-        additional_context: {},
-      },
-      system: null,
-      options: {
-        generate_embeddings: this.settings.generateEmbeddings,
-        entity_recognition: this.settings.entityRecognition,
-        wikify: this.settings.wikify,
-      },
-      provider: this.settings.useOpenAi ? "openai" : this.settings.useVertexAi ? "vertexai" : "azureai",
-      llmOptions: {
-        temperature: this.settings.llmOptions.temperature,
-        max_tokens: this.settings.llmOptions.max_tokens,
-      },
-      requestId: new ShortUniqueId({ length: 10 }).rnd(),
-    };
+		this.copyButton.onClickEvent(() => {
+			if (this.responseCode) {
+				navigator.clipboard.writeText(this.responseCode.innerText).then(
+					() => {
+						new Notice("Response copied to clipboard.");
+					},
+					(err) => {
+						console.error("Could not copy text: ", err);
+						new Notice("Failed to copy response to clipboard.");
+					}
+				);
+			}
+		});
 
-    // Add contents from attached files to the payload's additional context
-    if (!payload.user.additional_context) {
-      payload.user.additional_context = {};
-    }
-    
-    // Process attached files
-    for (const filePath of this.attachedFiles) {
-      const fileContent = await this.plugin.readAndFilterContent(filePath, []);
-      if (fileContent !== null) {
-        payload.user.additional_context[filePath] = fileContent;
-        
-        // Expand URLs in attached files if enabled
-        if (this.settings.interactivePanel.expandUrls) {
-          const urls = extractLinksFromContent(fileContent);
-          for (const url of urls) {
-            const content = await fetchUrlContent(url);
-            if (content) {
-              payload.user.additional_context[url] = content;
-            }
-          }
-        }
-        
-        // Resolve links if enabled
-        if (this.settings.interactivePanel.resolveLinks) {
-          const resolvedLinks = await this.plugin.resolveLinksForPath(filePath, []);
-          Object.assign(payload.user.additional_context, resolvedLinks);
-        }
-        
-        // Resolve backlinks if enabled
-        if (this.settings.interactivePanel.resolveBacklinks) {
-          const resolvedBacklinks = await this.plugin.resolveBacklinksForPath(filePath, []);
-          Object.assign(payload.user.additional_context, resolvedBacklinks);
-        }
-      }
-    }
-    
-    // Extract and expand URLs from the prompt text itself if enabled
-    if (this.settings.interactivePanel.expandUrls) {
-      const promptUrls = extractLinksFromContent(promptValue);
-      for (const url of promptUrls) {
-        const content = await fetchUrlContent(url);
-        if (content) {
-          payload.user.additional_context[url] = content;
-        }
-      }
-    }
+		// Response container setup
+		this.responseContainer = container.createDiv({
+			cls: "response-container",
+		});
+		this.responsePre = this.responseContainer.createEl("pre", {
+			cls: "ca-scrollable-response",
+		});
+		this.responseCode = this.responsePre.createEl("code");
+		this.responseCode.addClass("ca-response-code");
 
-    this.setLoading(true);
-    const notice = new Notice(`Running Interactive flow ...`, 0);
-    animateNotice(notice);
+		// Loading indicator setup
+		this.loadingIndicator = container.createDiv({
+			cls: "loading-indicator",
+		});
+		setIcon(this.loadingIndicator, "sync");
+		this.loadingIndicator.setText(" Waiting for response");
+		this.setLoading(false);
+	}
 
-    try {
-      const responseText = await this.plugin.caApiFetch(payload);
-      this.setLoading(false);
-      notice.hide();
-      clearTimeout(noticeTimeout);
-      this.renderResponse(responseText);
-      this.copyButton.show();
-    } catch (error) {
-      this.setLoading(false);
-      notice.hide();
-      console.error("Failed to fetch response from Cloud Atlas:", error);
-      new Notice("Failed to send payload to Cloud Atlas. Check the console for more details.");
-    }
-  }
+	private async handleSendClick(promptValue: string) {
+		// Build the payload using the promptValue and attached files
+		const payload: Payload = {
+			user: {
+				user_prompt: promptValue,
+				input: "See Additional Context and Respond to Prompt",
+				additional_context: {},
+			},
+			system: null,
+			options: {
+				generate_embeddings: this.settings.generateEmbeddings,
+				entity_recognition: this.settings.entityRecognition,
+				wikify: this.settings.wikify,
+			},
+			provider: this.settings.useOpenAi
+				? "openai"
+				: this.settings.useVertexAi
+				? "vertexai"
+				: "azureai",
+			llmOptions: {
+				temperature: this.settings.llmOptions.temperature,
+				max_tokens: this.settings.llmOptions.max_tokens,
+			},
+			requestId: new ShortUniqueId({ length: 10 }).rnd(),
+		};
 
-  private renderResponse(responseText: string) {
-      this.responseCode.setText(responseText);
-  }
+		// Add contents from attached files to the payload's additional context
+		if (!payload.user.additional_context) {
+			payload.user.additional_context = {};
+		}
 
+		// Process attached files
+		for (const filePath of this.attachedFiles) {
+			const fileContent = await this.plugin.readAndFilterContent(
+				filePath,
+				[]
+			);
+			if (fileContent !== null) {
+				payload.user.additional_context[filePath] = fileContent;
 
-  async onClose() {
-    // Nothing to clean up.
-  }
+				// Expand URLs in attached files if enabled
+				if (this.settings.interactivePanel.expandUrls) {
+					const urls = extractLinksFromContent(fileContent);
+					for (const url of urls) {
+						const content = await fetchUrlContent(url);
+						if (content) {
+							payload.user.additional_context[url] = content;
+						}
+					}
+				}
+
+				// Resolve links if enabled
+				if (this.settings.interactivePanel.resolveLinks) {
+					const resolvedLinks = await this.plugin.resolveLinksForPath(
+						filePath,
+						[]
+					);
+					Object.assign(
+						payload.user.additional_context,
+						resolvedLinks
+					);
+				}
+
+				// Resolve backlinks if enabled
+				if (this.settings.interactivePanel.resolveBacklinks) {
+					const resolvedBacklinks =
+						await this.plugin.resolveBacklinksForPath(filePath, []);
+					Object.assign(
+						payload.user.additional_context,
+						resolvedBacklinks
+					);
+				}
+			}
+		}
+
+		// Extract and expand URLs from the prompt text itself if enabled
+		if (this.settings.interactivePanel.expandUrls) {
+			const promptUrls = extractLinksFromContent(promptValue);
+			for (const url of promptUrls) {
+				const content = await fetchUrlContent(url);
+				if (content) {
+					payload.user.additional_context[url] = content;
+				}
+			}
+		}
+
+		this.setLoading(true);
+		const notice = new Notice(`Running Interactive flow ...`, 0);
+		animateNotice(notice);
+
+		try {
+			const responseText = await this.plugin.caApiFetch(payload);
+			this.setLoading(false);
+			notice.hide();
+			clearTimeout(noticeTimeout);
+			this.renderResponse(responseText);
+			this.copyButton.show();
+		} catch (error) {
+			this.setLoading(false);
+			notice.hide();
+			console.error("Failed to fetch response from Cloud Atlas:", error);
+			new Notice(
+				"Failed to send payload to Cloud Atlas. Check the console for more details."
+			);
+		}
+	}
+
+	private renderResponse(responseText: string) {
+		this.responseCode.setText(responseText);
+	}
+
+	async onClose() {
+		// Nothing to clean up.
+	}
 }

--- a/src/interactive_panel.ts
+++ b/src/interactive_panel.ts
@@ -1,4 +1,4 @@
-import { ItemView, Notice, WorkspaceLeaf, setIcon } from "obsidian";
+import { ItemView, Notice, WorkspaceLeaf, setIcon, setTooltip } from "obsidian";
 import CloudAtlasPlugin from "./main";
 
 import { CaRequestMsg, Payload, User } from "./interfaces";
@@ -241,6 +241,7 @@ export class InteractivePanel extends ItemView {
 					cls: "cloud-atlas-flow-btn-primary",
 				});
 				setIcon(removeButton, "trash-2");
+				setTooltip(removeButton, "Remove Note from Context");
 				removeButton.onClickEvent(() => {
 					this.attachedFiles.delete(file);
 					this.updateAttachedFilesList(filesList);
@@ -284,6 +285,7 @@ export class InteractivePanel extends ItemView {
 
 		// Make the attach button square and larger
 		setIcon(attachButton, "file-plus");
+		setTooltip(attachButton, "Attach Current Note to Context");
 		// Click listener for attaching the current note
 		attachButton.addEventListener("click", () => {
 			const activeFile = this.app.workspace.getActiveFile();
@@ -305,6 +307,7 @@ export class InteractivePanel extends ItemView {
 		});
 
 		setIcon(sendButton, "play");
+		setTooltip(sendButton, "Send to LLM");
 		// Make the send button square and larger so the text fits
 
 		sendButton.addEventListener("click", async () => {
@@ -321,12 +324,15 @@ export class InteractivePanel extends ItemView {
 			text: "New Interactive",
 		});
 
-		setIcon(newInteractiveButton, "plus");
+		setIcon(newInteractiveButton, "list-restart");
+		setTooltip(newInteractiveButton, "New Interactive Session");
 
 		newInteractiveButton.addEventListener("click", () => {
 			this.emptyAttachedFilesList(this.attachedFilesListEl);
 			this.history = [];
 			this.promptTextbox.value = "";
+			this.responseCode.innerText = "";
+			this.copyButton.hide();
 		});
 
 		// Keydown listener for Ctrl+Enter to submit the prompt
@@ -343,13 +349,24 @@ export class InteractivePanel extends ItemView {
 		this.updateAttachedFilesList(this.attachedFilesListEl);
 
 		// Response header and Copy button setup
-		const responseHeader = container.createEl("h4", { text: "Response" });
-		this.copyButton = container.createEl("button", {
-			text: "Copy to Clipboard",
-			cls: "ca-a-interactive-copy-button",
+		const responseHeaderContainer = container.createDiv({
+			cls: "response-header-container",
 		});
+		responseHeaderContainer.style.display = "flex";
+		responseHeaderContainer.style.justifyContent = "space-between";
+		responseHeaderContainer.style.alignItems = "center";
+		responseHeaderContainer.style.marginBottom = "8px";
+
+		responseHeaderContainer.createEl("h4", { text: "Response" });
+		this.copyButton = responseHeaderContainer.createEl("button", {
+			text: "Copy to Clipboard",
+			cls: "ca-a-interactive-copy-button cloud-atlas-flow-btn-primary",
+		});
+
+		setIcon(this.copyButton, "clipboard-copy");
+		setTooltip(this.copyButton, "Copy to Clipboard");
+
 		this.copyButton.hide();
-		responseHeader.insertAdjacentElement("afterend", this.copyButton);
 
 		this.copyButton.onClickEvent(() => {
 			if (this.responseCode) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -4,8 +4,7 @@ export interface LlmOptions {
 }
 
 export interface Payload {
-	user: User;
-	system: string | null;
+	messages: CaRequestMsg[];
 	options: Options;
 	provider: "azureai" | "openai" | "vertexai" | string;
 	llmOptions: LlmOptions;
@@ -14,6 +13,12 @@ export interface Payload {
 	// V2 is the async version through Supabase
 	// If not set, defaults to V1 serverside
 	version?: "V1" | "V2";
+}
+
+export interface CaRequestMsg {
+	user: User
+	system: string | null
+	assistant: string | null
 }
 
 export interface Options {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,10 +3,17 @@ export interface LlmOptions {
 	max_tokens?: number;
 }
 
+export interface FlowResponse {
+	response: string;
+	config: FlowConfig;
+	payload: Payload;
+}
+
 export interface Payload {
 	messages: CaRequestMsg[];
 	options: Options;
 	provider: "auto" | "openai" | "vertexai" | string;
+	model: string | null;
 	llmOptions: LlmOptions;
 	requestId: string;
 	// V1 is the legacy sync version
@@ -85,6 +92,7 @@ export interface AutoProcessingConfig {
 	flow: string;
 	outputNameTemplate: string; // e.g., "${basename}-processed"
 	expandUrls?: boolean;
+	model?: string | null;
 }
 
 export interface CloudAtlasPluginSettings {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -44,7 +44,7 @@ export interface FlowConfig {
 	llmOptions: LlmOptions;
 	additional_context: AdditionalContext;
 	model: string | null;
-	// Add other flow properties as needed
+	can_delegate: boolean;
 }
 
 export enum NamedEntity {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -86,3 +86,34 @@ export interface AutoProcessingConfig {
 	outputNameTemplate: string; // e.g., "${basename}-processed"
 	expandUrls?: boolean;
 }
+
+export interface CloudAtlasPluginSettings {
+	apiKey: string;
+	advancedOptions: boolean;
+	useOpenAi: boolean;
+	useVertexAi: boolean;
+	previewMode: boolean;
+	entityRecognition: boolean;
+	generateEmbeddings: boolean;
+	wikify: string[];
+	canvasResolveLinks: boolean;
+	canvasResolveBacklinks: boolean;
+	developmentMode: boolean;
+	llmOptions: LlmOptions;
+	timeoutMins: number;
+	openAiSettings: OpenAiSettings;
+	azureAiSettings: AzureAiSettings;
+	provider: string;
+	registeredFlows: string[];
+	createNewFile: boolean; // Whether to create a new file for flow responses instead of modifying the current file
+	outputFileTemplate: string; // Template for naming output files
+	autoProcessing: {
+		enabled: boolean;
+		defaultFlow: string;
+	};
+	interactivePanel: {
+		resolveLinks: boolean;
+		resolveBacklinks: boolean;
+		expandUrls: boolean;
+	};
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,7 @@ export interface Payload {
 	user: User;
 	system: string | null;
 	options: Options;
-	provider: "azureai" | "openai" | "vertexai";
+	provider: "azureai" | "openai" | "vertexai" | string;
 	llmOptions: LlmOptions;
 	requestId: string;
 	// V1 is the legacy sync version
@@ -38,10 +38,12 @@ export interface FlowConfig {
 	mode: string | null;
 	resolveBacklinks: boolean;
 	resolveForwardLinks: boolean;
+	expandUrls: boolean;
 	exclusionPatterns: string[];
 	frontMatterOffset: number;
 	llmOptions: LlmOptions;
 	additional_context: AdditionalContext;
+	model: string | null;
 	// Add other flow properties as needed
 }
 
@@ -77,4 +79,5 @@ export interface AutoProcessingConfig {
 	enabled: boolean;
 	flow: string;
 	outputNameTemplate: string; // e.g., "${basename}-processed"
+	expandUrls?: boolean;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -72,3 +72,9 @@ export interface AzureAiSettings {
 	deploymentId: string;
 	endpoint: string;
 }
+
+export interface AutoProcessingConfig {
+	enabled: boolean;
+	flow: string;
+	outputNameTemplate: string; // e.g., "${basename}-processed"
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1291,6 +1291,10 @@ export default class CloudAtlasPlugin extends Plugin {
 			console.log(`Processing with flow: ${config.flow}`);
 			const result = await this.flowToResponse(file, config.flow);
 
+			// Add source file link to the result
+			const sourceLink = `\n\n---\nSource: [[${file.path}|${file.basename}]]`;
+			const resultWithSourceLink = result + sourceLink;
+
 			// Generate and save output file
 			const outputFilename = this.generateOutputFilename(
 				file,
@@ -1300,12 +1304,12 @@ export default class CloudAtlasPlugin extends Plugin {
 			try {
 				const existingFile = getFileByPath(outputPath, this.app);
 				if (existingFile) {
-					await this.app.vault.modify(existingFile, result);
+					await this.app.vault.modify(existingFile, resultWithSourceLink);
 				} else {
-					await this.app.vault.create(outputPath, result);
+					await this.app.vault.create(outputPath, resultWithSourceLink);
 				}
 			} catch (e) {
-				await this.app.vault.create(outputPath, result);
+				await this.app.vault.create(outputPath, resultWithSourceLink);
 			}
 
 			// Success notice

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,6 +25,10 @@ export interface CloudAtlasPluginSettings {
 	azureAiSettings: AzureAiSettings;
 	provider: string;
 	registeredFlows: string[];
+	autoProcessing: {
+		enabled: boolean;
+		defaultFlow: string;
+	};
 }
 
 export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
@@ -384,6 +388,38 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 								});
 						});
 				});
+			}
+
+			// Add Auto-Processing section
+			containerEl.createEl("h2", { text: "Auto-Processing" });
+			
+			new Setting(containerEl)
+				.setName("Enable Auto-Processing")
+				.setDesc("Automatically process files added to 'sources' subfolders")
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.autoProcessing.enabled)
+						.onChange(async (value) => {
+							this.plugin.settings.autoProcessing.enabled = value;
+							await this.plugin.saveSettings();
+						})
+				);
+
+			if (this.plugin.settings.autoProcessing.enabled) {
+				new Setting(containerEl)
+					.setName("Default Flow")
+					.setDesc("The default flow to use for auto-processing")
+					.addDropdown((dropdown) => {
+						// Add all registered flows to the dropdown
+						this.plugin.settings.registeredFlows.forEach(flow => {
+							dropdown.addOption(flow, flow);
+						});
+						dropdown.setValue(this.plugin.settings.autoProcessing.defaultFlow);
+						dropdown.onChange(async (value) => {
+							this.plugin.settings.autoProcessing.defaultFlow = value;
+							await this.plugin.saveSettings();
+						});
+					});
 			}
 		}
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -29,6 +29,11 @@ export interface CloudAtlasPluginSettings {
 		enabled: boolean;
 		defaultFlow: string;
 	};
+	interactivePanel: {
+		resolveLinks: boolean;
+		resolveBacklinks: boolean;
+		expandUrls: boolean;
+	};
 }
 
 export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
@@ -421,6 +426,45 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 						});
 					});
 			}
+
+			// Interactive Panel Settings
+			containerEl.createEl("h2", { text: "Interactive Panel" });
+			
+			new Setting(containerEl)
+				.setName("Resolve links")
+				.setDesc("Add linked notes as additional context in interactive panel")
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.interactivePanel.resolveLinks)
+						.onChange(async (value) => {
+							this.plugin.settings.interactivePanel.resolveLinks = value;
+							await this.plugin.saveSettings();
+						})
+				);
+			
+			new Setting(containerEl)
+				.setName("Resolve backlinks")
+				.setDesc("Add backlinks as additional context in interactive panel")
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.interactivePanel.resolveBacklinks)
+						.onChange(async (value) => {
+							this.plugin.settings.interactivePanel.resolveBacklinks = value;
+							await this.plugin.saveSettings();
+						})
+				);
+
+			new Setting(containerEl)
+				.setName("Expand URLs")
+				.setDesc("Fetch and include content from URLs found in notes and prompt")
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.interactivePanel.expandUrls)
+						.onChange(async (value) => {
+							this.plugin.settings.interactivePanel.expandUrls = value;
+							await this.plugin.saveSettings();
+						})
+				);
 		}
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -281,17 +281,17 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 			new Setting(containerEl)
 				.setName("LLM max response tokens")
 				.setDesc(
-					"Set maximum tokens returned in the response, defaults to 2000, and maximum is 4096."
+					"Set maximum tokens returned in the response, defaults to 2000, and maximum is 200000."
 				)
 				.addText((text) =>
 					text
 						.setValue(
 							this.plugin.settings.llmOptions.max_tokens?.toString() ||
-								"2000"
+								"5000"
 						)
 						.onChange(async (value) => {
 							const v =
-								Number(value) > 4096 ? 4096 : Number(value);
+								Number(value) > 200000 ? 200000 : Number(value);
 							this.plugin.settings.llmOptions.max_tokens = v;
 							await this.plugin.saveSettings();
 						})
@@ -397,10 +397,12 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 
 			// Add Auto-Processing section
 			containerEl.createEl("h2", { text: "Auto-Processing" });
-			
+
 			new Setting(containerEl)
 				.setName("Enable Auto-Processing")
-				.setDesc("Automatically process files added to 'sources' subfolders")
+				.setDesc(
+					"Automatically process files added to 'sources' subfolders"
+				)
 				.addToggle((toggle) =>
 					toggle
 						.setValue(this.plugin.settings.autoProcessing.enabled)
@@ -416,12 +418,15 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 					.setDesc("The default flow to use for auto-processing")
 					.addDropdown((dropdown) => {
 						// Add all registered flows to the dropdown
-						this.plugin.settings.registeredFlows.forEach(flow => {
+						this.plugin.settings.registeredFlows.forEach((flow) => {
 							dropdown.addOption(flow, flow);
 						});
-						dropdown.setValue(this.plugin.settings.autoProcessing.defaultFlow);
+						dropdown.setValue(
+							this.plugin.settings.autoProcessing.defaultFlow
+						);
 						dropdown.onChange(async (value) => {
-							this.plugin.settings.autoProcessing.defaultFlow = value;
+							this.plugin.settings.autoProcessing.defaultFlow =
+								value;
 							await this.plugin.saveSettings();
 						});
 					});
@@ -429,39 +434,55 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 
 			// Interactive Panel Settings
 			containerEl.createEl("h2", { text: "Interactive Panel" });
-			
+
 			new Setting(containerEl)
 				.setName("Resolve links")
-				.setDesc("Add linked notes as additional context in interactive panel")
+				.setDesc(
+					"Add linked notes as additional context in interactive panel"
+				)
 				.addToggle((toggle) =>
 					toggle
-						.setValue(this.plugin.settings.interactivePanel.resolveLinks)
+						.setValue(
+							this.plugin.settings.interactivePanel.resolveLinks
+						)
 						.onChange(async (value) => {
-							this.plugin.settings.interactivePanel.resolveLinks = value;
+							this.plugin.settings.interactivePanel.resolveLinks =
+								value;
 							await this.plugin.saveSettings();
 						})
 				);
-			
+
 			new Setting(containerEl)
 				.setName("Resolve backlinks")
-				.setDesc("Add backlinks as additional context in interactive panel")
+				.setDesc(
+					"Add backlinks as additional context in interactive panel"
+				)
 				.addToggle((toggle) =>
 					toggle
-						.setValue(this.plugin.settings.interactivePanel.resolveBacklinks)
+						.setValue(
+							this.plugin.settings.interactivePanel
+								.resolveBacklinks
+						)
 						.onChange(async (value) => {
-							this.plugin.settings.interactivePanel.resolveBacklinks = value;
+							this.plugin.settings.interactivePanel.resolveBacklinks =
+								value;
 							await this.plugin.saveSettings();
 						})
 				);
 
 			new Setting(containerEl)
 				.setName("Expand URLs")
-				.setDesc("Fetch and include content from URLs found in notes and prompt")
+				.setDesc(
+					"Fetch and include content from URLs found in notes and prompt"
+				)
 				.addToggle((toggle) =>
 					toggle
-						.setValue(this.plugin.settings.interactivePanel.expandUrls)
+						.setValue(
+							this.plugin.settings.interactivePanel.expandUrls
+						)
 						.onChange(async (value) => {
-							this.plugin.settings.interactivePanel.expandUrls = value;
+							this.plugin.settings.interactivePanel.expandUrls =
+								value;
 							await this.plugin.saveSettings();
 						})
 				);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,8 @@ export interface CloudAtlasPluginSettings {
 		resolveBacklinks: boolean;
 		expandUrls: boolean;
 	};
+	createNewFile: boolean;
+	outputFileTemplate: string;
 }
 
 export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
@@ -260,23 +262,23 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 		if (this.plugin.settings.advancedOptions) {
 			containerEl.createEl("h2", { text: "LLM" });
 
-			new Setting(containerEl)
-				.setName("LLM temperature")
-				.setDesc(
-					'Set default temperature for the LLM, the higher the temperature the more "creative" the LLM will be, default is usually around 0.8.'
-				)
-				.addText((text) =>
-					text
-						.setValue(
-							this.plugin.settings.llmOptions.temperature?.toString() ||
-								"0.8"
-						)
-						.onChange(async (value) => {
-							this.plugin.settings.llmOptions.temperature =
-								Number(value);
-							await this.plugin.saveSettings();
-						})
-				);
+			// new Setting(containerEl)
+			// 	.setName("LLM temperature")
+			// 	.setDesc(
+			// 		'Set default temperature for the LLM, the higher the temperature the more "creative" the LLM will be, default is usually around 0.8.'
+			// 	)
+			// 	.addText((text) =>
+			// 		text
+			// 			.setValue(
+			// 				this.plugin.settings.llmOptions.temperature?.toString() ||
+			// 					"0.8"
+			// 			)
+			// 			.onChange(async (value) => {
+			// 				this.plugin.settings.llmOptions.temperature =
+			// 					Number(value);
+			// 				await this.plugin.saveSettings();
+			// 			})
+			// 	);
 
 			new Setting(containerEl)
 				.setName("LLM max response tokens")
@@ -297,6 +299,37 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 						})
 				);
 
+			// Add new settings for flow response handling
+			containerEl.createEl("h2", { text: "Flow Response Handling" });
+			
+			new Setting(containerEl)
+				.setName("Create new file for responses")
+				.setDesc("Create a new file for each flow response instead of appending to the current file")
+				.addToggle((toggle) =>
+					toggle
+						.setValue(this.plugin.settings.createNewFile || false)
+						.onChange(async (value) => {
+							this.plugin.settings.createNewFile = value;
+							await this.plugin.saveSettings();
+							this.display();
+						})
+				);
+			
+			// Only show output file template if createNewFile is enabled
+			if (this.plugin.settings.createNewFile) {
+				new Setting(containerEl)
+					.setName("Output file template")
+					.setDesc("Template for naming output files. Available variables: ${basename} (current file name), ${flow} (flow name), ${timestamp} (Unix timestamp for better sorting)")
+					.addText((text) =>
+						text
+							.setValue(this.plugin.settings.outputFileTemplate || "${basename}-${flow}")
+							.onChange(async (value) => {
+								this.plugin.settings.outputFileTemplate = value;
+								await this.plugin.saveSettings();
+							})
+					);
+			}
+
 			if (this.plugin.settings.provider === "cloudatlas") {
 				new Setting(containerEl)
 					.setName("Timeout minutes")
@@ -314,6 +347,7 @@ export class CloudAtlasGlobalSettingsTab extends PluginSettingTab {
 								await this.plugin.saveSettings();
 							})
 					);
+				
 				containerEl.createEl("h2", { text: "Canvas flows" });
 
 				new Setting(containerEl)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import WordExtractor from "word-extractor";
-import { AdditionalContext, Payload, User } from "./interfaces";
+import { AdditionalContext, CaRequestMsg, Payload, User } from "./interfaces";
 import {
 	App,
 	LinkCache,
@@ -59,13 +59,13 @@ export function combinePayloads(
 		return base;
 	}
 	const additional_context: AdditionalContext = {};
-	Object.assign(additional_context, base.user.additional_context);
-	Object.assign(additional_context, override.user.additional_context);
+	Object.assign(additional_context, base.messages[base.messages.length - 1].user.additional_context);
+	Object.assign(additional_context, override.messages[override.messages.length - 1].user.additional_context);
 
-	const input = joinStrings(base.user.input, override.user.input);
+	const input = joinStrings(base.messages[base.messages.length - 1].user.input, override.messages[override.messages.length - 1].user.input);
 	const user_prompt = joinStrings(
-		base.user.user_prompt,
-		override.user.user_prompt
+		base.messages[base.messages.length - 1].user.user_prompt,
+		override.messages[override.messages.length - 1].user.user_prompt
 	);
 
 	const user: User = {
@@ -74,9 +74,15 @@ export function combinePayloads(
 		additional_context,
 	};
 
-	return {
+	const caRequestMsg: CaRequestMsg = {
 		user,
-		system: override.system || base.system,
+		system: override.messages[override.messages.length - 1].system || base.messages[base.messages.length - 1].system,
+		assistant: override.messages[override.messages.length - 1].assistant || base.messages[base.messages.length - 1].assistant,
+		
+	};
+
+	return {
+		messages: [caRequestMsg],
 		options: override.options || base.options,
 		provider: override.provider || base.provider,
 		llmOptions: override.llmOptions || base.llmOptions,

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,7 @@ button.cloud-atlas-flow-btn-primary {
 	background-color: var(--text-accent);
 	color: var(--background-primary);
 	padding: var(--size-4-2);
+	margin: var(--size-4-1);
 	border-radius: var(--size-4-4);
 	cursor: pointer;
 	height: var(--size-4-8);
@@ -219,17 +220,6 @@ table.cloud-atlas-flow-table td.cloud-atlas-flow-td-quarter {
   padding: 5px 10px;
   border-radius: 3px;
   cursor: pointer;
-}
-
-.ca-attach-note-button {
-  background-color: var(--interactive-accent);
-  border: none;
-  padding: 5px 10px;
-  border-radius: 3px;
-  cursor: pointer;
-  &:hover::before {
-    content: "Add current note to the prompt ";
-  }
 }
 
 .ca-interactive-prompt-textbox {


### PR DESCRIPTION
+ `can_delegate` metadata property allows flows to call other flows, must be paired with `{{ca-capabilities}}` macro
+ Command to create an index of a subfolder with links, for easier usage in flows
+ Command to set up autoprocessing in a folder
+ Autoprocessing of notes in folders
+ Perplexity support
+ `Auto` provider that selects between OpenAi and Perplexity depending on the user prompt and input
+ Memory for the interactive panel
+ Tooltips to all buttons
+ Link and backlink resolution for interactive pane notes
+ URL resolution with the `expand_url` metadata property
+ `model` metadata property
+ Settings cleanup
+ Option to save any flow execution to a file with destination templating